### PR TITLE
Temporarily replace binding

### DIFF
--- a/binding/requirements.txt
+++ b/binding/requirements.txt
@@ -1,4 +1,4 @@
-gojsonnet
+jsonnet
 pyright
 black
 flake8


### PR DESCRIPTION
I am having problem adding the gojsonnet binding to the internal pypi repo. 
Replacing temporarily with the C++ version while I figure that out.