### PR TITLE
Disable new line check to cut the first release

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,13 @@ repos:
       - id: check-xml
       - id: check-yaml
       - id: detect-private-key
-      - id: end-of-file-fixer
+      # Disable it to cut the first release of the libraries.
+      # Since we moved the changelog files, the new ones are empty
+      # but the first release is not 0.0.1.
+      # It seems Craft is not adding the newline as it does not
+      # figure out the release we try to cut is the first one.
+      # Once the first is cut we can add it back
+      # - id: end-of-file-fixer
       - id: trailing-whitespace
       - id: fix-encoding-pragma
         args: ["--remove"]


### PR DESCRIPTION
I think this should allow us to cut the first release when the changelog file is empty. 
If it works, I'll look into Craft to see whether the current behavior is expected (it does not recognize that 0.0.3 is actually the first release in the changelog file) or whether it is a bug.