### PR TITLE
Fix branch name in the build workflow

### DIFF
--- a/.github/workflows/build-jsonish.yaml
+++ b/.github/workflows/build-jsonish.yaml
@@ -6,7 +6,7 @@ on:
   push:
     branches:
       - main
-      - release-jsonish/**
+      - release-sentry-jsonish/**
 
 jobs:
   dist:

--- a/.github/workflows/build-jsonnet.yaml
+++ b/.github/workflows/build-jsonnet.yaml
@@ -6,7 +6,7 @@ on:
   push:
     branches:
       - main
-      - release-jsonnet/**
+      - release-sentry-jsonnet/**
 
 jobs:
   dist:

--- a/sentry_jsonish/.craft.yml
+++ b/sentry_jsonish/.craft.yml
@@ -7,7 +7,6 @@ changelogPolicy: auto
 preReleaseCommand: bash ../sbin/bump-version.sh
 releaseBranchPrefix: release-sentry-jsonish
 targets:
-  - name: github
   - name: pypi
   - name: sentry-pypi
     internalPypiRepo: getsentry/pypi


### PR DESCRIPTION
We were not running the build workflow on the release branch thus we were not creating the artifacts.