### PR TITLE
fix(service-registry): Add solution for imports

### DIFF
--- a/sentry_jsonnet/src/sentry_jsonnet/__init__.py
+++ b/sentry_jsonnet/src/sentry_jsonnet/__init__.py
@@ -111,6 +111,7 @@ def jsonnet(
     native_callbacks: dict[
         str, tuple[tuple[str, ...], Callable[..., Any]]
     ] = None,
+    ext_packages: Sequence[Path | str] = (), # Paths for any additional ext packages containing resources
 ) -> JSONish:
     if base_dir is None:
         # this choice of default base_dir makes all paths source-relative
@@ -123,6 +124,8 @@ def jsonnet(
     _filename = str(base_dir / filename)
 
     import_paths = [base_dir / path for path in import_paths]
+    import_packages = [path for path in ext_packages]
+    import_paths.extend(import_packages)
     _jpathdir = [str(path) for path in import_paths]
 
     if ext_vars is None:

--- a/sentry_jsonnet/src/sentry_jsonnet/__init__.py
+++ b/sentry_jsonnet/src/sentry_jsonnet/__init__.py
@@ -126,7 +126,9 @@ def jsonnet(
     _filename = str(base_dir / filename)
 
     import_paths = [base_dir / path for path in import_paths]
-    import_packages = [path for path in ext_packages]
+    import_packages = [
+        path for path in ext_packages
+    ]  # we can't concatenate import package paths to base_dir
     import_paths.extend(import_packages)
     _jpathdir = [str(path) for path in import_paths]
 

--- a/sentry_jsonnet/src/sentry_jsonnet/__init__.py
+++ b/sentry_jsonnet/src/sentry_jsonnet/__init__.py
@@ -111,7 +111,9 @@ def jsonnet(
     native_callbacks: dict[
         str, tuple[tuple[str, ...], Callable[..., Any]]
     ] = None,
-    ext_packages: Sequence[Path | str] = (), # Paths for any additional ext packages containing resources
+    ext_packages: Sequence[
+        Path | str
+    ] = (),  # Paths for any additional ext packages containing resources.
 ) -> JSONish:
     if base_dir is None:
         # this choice of default base_dir makes all paths source-relative


### PR DESCRIPTION
This PR adds a fix for import issues when materializing a jsonnet with missing file paths (due to resources being in an external python package).

The problem was that the import_paths were all auto concatentated to the base_dir (if specified), which would result in path errors when trying to use paths for packages not in the base_dir.

The fix is to add an additional ext_packages arg that bypasses the base_dir path concatentation