### PR TITLE
chore(deps): bump black from 23.9.1 to 26.3.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
         files: ^sentry_jsonish/.+
         args: [--settings-path=./sentry_jsonish/pyproject.toml]
   - repo: https://github.com/psf/black
-    rev: 23.9.1
+    rev: 26.3.1
     hooks:
       - id: black
         files: ^sentry_jsonnet/.+

--- a/sentry_jsonnet/requirements-dev.txt
+++ b/sentry_jsonnet/requirements-dev.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements-dev.txt --strip-extras requirements-dev.in
 #
-black==23.9.1
+black==26.3.1
     # via -r requirements-dev.in
 cfgv==3.4.0
     # via pre-commit
@@ -28,7 +28,7 @@ packaging==23.1
     # via
     #   black
     #   pytest
-pathspec==0.11.2
+pathspec==1.1.1
     # via black
 platformdirs==3.10.0
     # via
@@ -42,6 +42,8 @@ pyright==1.1.328
     # via -r requirements-dev.in
 pytest==7.4.2
     # via -r requirements-dev.in
+pytokens==0.4.1
+    # via black
 pyyaml==6.0.1
     # via pre-commit
 sentry-forked-jsonnet==0.20.0.post4


### PR DESCRIPTION
## Summary
- Bumps `black` from 23.9.1 → 26.3.1 to remediate a Semgrep-flagged supply-chain vulnerability
- Updates both `.pre-commit-config.yaml` and `sentry_jsonnet/requirements-dev.txt` (regenerated via `pip-compile`)
- No formatting changes needed — `black --check` is clean against the existing Python files

Linear: [INF-1784](https://linear.app/getsentry/issue/INF-1784/black-vulnerability-in-getsentryjsonnet-libs)

## Test plan
- [ ] CI passes
- [ ] pre-commit `black` hook runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)